### PR TITLE
Message targetmode limitation.

### DIFF
--- a/app/TeamSpeak3Bot.php
+++ b/app/TeamSpeak3Bot.php
@@ -414,6 +414,7 @@ class TeamSpeak3Bot
     public function onMessage(Event $event)
     {
         $data = $event->getData();
+        $mode = $this->parseMessageMode(@$data['targetmode']);
         if (@$data['invokername'] == $this->name || @$data['invokeruid'] == 'serveradmin') {
             return;
         }
@@ -435,7 +436,13 @@ class TeamSpeak3Bot
                         }
                     } else if (@$config->CONFIG['permissions'] != "everyone") {
                         continue;
-                    }   
+                    }
+
+                    if (@is_array($config->CONFIG['limitation']) && $mode != null) {
+                        if(@!in_array($mode, $config->CONFIG['limitation'])) {
+                            continue;
+                        }
+                    }
                     $info = $data;
 
                     $info['triggerUsed'] = $trigger;
@@ -528,6 +535,24 @@ class TeamSpeak3Bot
     public function onException(Ts3Exception $e)
     {
         $this->printOutput("Error {$e->getCode()}: {$e->getMessage()}");
+    }
+
+    public function parseMessageMode($input)
+    {
+        switch($input) {
+            case 1:
+                return "private";
+                break;
+            case 2:
+                return "channel";
+                break;
+            case 3:
+                return "server";
+                break;
+            default:
+                return null;
+                break;
+        }
     }
 
 }

--- a/config/plugins/Seen.json
+++ b/config/plugins/Seen.json
@@ -10,5 +10,8 @@
   "groups":[
   "10"
   ],
+  "limitation":[
+  "private"
+  ],
   "usage": "Usage: !seen [user]"
 }


### PR DESCRIPTION
You can now limit messages for certain targetmodes (private, channel, server).
You don't need to set it if you want it to trigger for all 3 options. It's just optional value. + Added example for 'Seen' plugin.